### PR TITLE
fix: Sync __version__ with pyproject.toml (0.3.0)

### DIFF
--- a/rustchain_mcp/__init__.py
+++ b/rustchain_mcp/__init__.py
@@ -1,3 +1,3 @@
 """RustChain + BoTTube MCP Server — AI agent tools for the RustChain blockchain and BoTTube video platform."""
 
-__version__ = "0.1.0"
+__version__ = "0.3.0"


### PR DESCRIPTION
## Bug Fix

**Issue**: Version mismatch
- pyproject.toml: 0.3.0
- rustchain_mcp/__init__.py: 0.1.0

**Fix**: Updated __init__.py to match pyproject.toml

**Severity**: Cosmetic

**Related**: https://github.com/Scottcjn/rustchain-bounties/issues/386