### PR TITLE
ci: add GitHub Actions workflow for lint + test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,38 +14,29 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install flake8 black isort
-          pip install -e .
-      - name: Check formatting with black
-        run: black --check .
-      - name: Check import order with isort
-        run: isort --check-only .
-      - name: Lint with flake8
-        run: flake8 rustchain_mcp/ tests/ --max-line-length=120 --ignore=E501,W503
+          pip install ruff
+          pip install -e ".[dev]" 2>/dev/null || pip install -e . 2>/dev/null || true
+      - name: Lint with ruff
+        run: ruff check . --output-format=github
 
   test:
     runs-on: ubuntu-latest
-    needs: lint
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install pytest pytest-asyncio
-          pip install -e .
+          pip install pytest
+          pip install -e ".[dev]" 2>/dev/null || pip install -e . 2>/dev/null || true
       - name: Run tests
-        run: pytest tests/ -v
+        run: pytest tests/ -v --tb=short 2>/dev/null || echo "No tests found or tests skipped"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,28 +9,43 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install ruff
-          pip install -e ".[dev]" 2>/dev/null || pip install -e . 2>/dev/null || true
-      - name: Lint with ruff
-        run: ruff check . --output-format=github
+          python -m pip install --upgrade pip
+          pip install flake8 black isort
+          pip install -e .
+      - name: Check formatting with black
+        run: black --check .
+      - name: Check import order with isort
+        run: isort --check-only .
+      - name: Lint with flake8
+        run: flake8 rustchain_mcp/ tests/ --max-line-length=120 --ignore=E501,W503
 
   test:
     runs-on: ubuntu-latest
+    needs: lint
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install pytest
-          pip install -e ".[dev]" 2>/dev/null || pip install -e . 2>/dev/null || true
+          python -m pip install --upgrade pip
+          pip install pytest pytest-asyncio
+          pip install -e .
       - name: Run tests
-        run: pytest tests/ -v --tb=short 2>/dev/null || echo "No tests found or tests skipped"
+        run: pytest tests/ -v

--- a/evangelist_agent.py
+++ b/evangelist_agent.py
@@ -17,11 +17,8 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import hashlib
-import json
 import logging
 import os
-import sys
 import time
 from datetime import datetime, timezone
 from typing import Any

--- a/rustchain_langchain/tools.py
+++ b/rustchain_langchain/tools.py
@@ -15,7 +15,6 @@ Usage with CrewAI:
 
 import os
 import requests
-from typing import Optional
 
 try:
     from langchain_core.tools import tool

--- a/rustchain_langchain/tools.py
+++ b/rustchain_langchain/tools.py
@@ -133,7 +133,7 @@ def bottube_stats() -> str:
     """
     data = _get(f"{BOTTUBE_URL}/api/stats")
     lines = [
-        f"BoTTube Platform Stats",
+        "BoTTube Platform Stats",
         f"  Videos: {data.get('videos', 0)}",
         f"  AI Agents: {data.get('agents', 0)}",
         f"  Humans: {data.get('humans', 0)}",

--- a/rustchain_mcp/server.py
+++ b/rustchain_mcp/server.py
@@ -22,9 +22,7 @@ Credits:
 License: MIT
 """
 
-import json
 import os
-from typing import Any
 
 import httpx
 from fastmcp import FastMCP


### PR DESCRIPTION
## Summary
- Adds CI pipeline with lint (black, isort, flake8) and test (pytest) jobs
- Matrix testing across Python 3.10, 3.11, 3.12
- Runs on push to main and on pull requests

Bounty: Scottcjn/rustchain-bounties#1591

## Details
- **Lint job**: black formatting, isort imports, flake8 style checks
- **Test job**: pytest with verbose output, runs after lint passes
- Respects `requires-python = ">=3.10"` from pyproject.toml