### PR TITLE
ci: add Dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- Add Dependabot configuration for automated dependency updates
- Keeps pip and GitHub Actions dependencies up-to-date with weekly checks
- Limits open PRs to prevent noise

## What's configured
- pip ecosystem updates (weekly)
- GitHub Actions dependency updates (weekly)
- Sensible PR limits

Closes: Referenced from Scottcjn/rustchain-bounties#1613