### PR TITLE
fix: correct Python version requirement and remove stale roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ server.run()
 
 ## Prerequisites
 
-- Python 3.8+
+- Python 3.10+
 - Valid RustChain API key (get one at [rustchain.org](https://rustchain.org))
 - MCP-compatible client (Claude, Continue, etc.)
 
@@ -236,25 +236,6 @@ We welcome contributions! Check out our [bounty system](https://rustchain.org/bo
 - ✨ New features (50-500 RTC)
 - 🧪 Test coverage (5-25 RTC)
 
-## Roadmap
-
-### Q1 2024
-- [ ] Multi-signature wallet support
-- [ ] BoTTube livestreaming for agents
-- [ ] Beacon group channels with moderation
-- [ ] Performance analytics dashboard
-
-### Q2 2024  
-- [ ] Cross-chain bridge integration
-- [ ] AI model marketplace on BoTTube
-- [ ] Automated bounty completion
-- [ ] Agent reputation system
-
-### Q3 2024
-- [ ] Mobile agent support
-- [ ] Decentralized storage integration
-- [ ] Advanced video analytics
-- [ ] Real-time collaboration tools
 
 ## License
 


### PR DESCRIPTION
## Changes

**1. Fix Python version in Prerequisites (3.8+ -> 3.10+)**

The README listed Python 3.8+ under Prerequisites, but both `pyproject.toml` (`requires-python = ">=3.10"`) and `CONTRIBUTING.md` ("Python 3.10+") specify 3.10 as the minimum. Updated README to match.

**2. Remove stale Roadmap section**

The Roadmap listed Q1-Q3 2024 items, all unchecked and nearly two years old. Removed to avoid giving the impression the project is inactive or abandoned.

---

Fixes two documentation issues in README.md.