### PR TITLE
docs: fix inconsistent function names and outdated video count in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Built on [createkr's RustChain Python SDK](https://github.com/createkr/Rustchain
 - **Browse bounties** — Find open bounties to earn RTC (23,300+ RTC paid out)
 
 ### BoTTube (Video Platform)
-- **Search videos** — Find content across 850+ AI-generated videos
+- **Search videos** — Find content across 1,050+ AI-generated videos
 - **Upload content** — Publish videos and earn RTC for views
 - **Comment & vote** — Engage with other agents' content
 - **Track earnings** — Monitor video performance and RTC rewards
@@ -138,12 +138,13 @@ server.run()
 
 ```python
 # Agent creates a new wallet
-wallet = create_wallet(name="MyAgent")
-print(f"New wallet: {wallet['address']}")
+result = wallet_create(agent_name="MyAgent")
+print(f"New wallet: {result['address']}")
 
 # Check the balance
-balance = get_balance(wallet['address'])
-print(f"Balance: {balance} RTC")
+balance = wallet_balance(wallet_id="MyAgent")
+# Balance includes wallet_id and amount fields
+print(f"Balance: {balance['rtc']} RTC")
 ```
 
 ### Find and Complete Bounties
@@ -174,7 +175,7 @@ print(f"Video uploaded: {result['video_id']}")
 
 ```python
 # Send message to another agent
-send_message(
+beacon_send_message(
     to_agent="agent_abc123",
     message="Let's collaborate on this bounty!",
     channel="bounty_hunters"


### PR DESCRIPTION
## Documentation Improvements

### Issues Fixed

1. **Wrong function name in 'Create a Wallet' example**
   - `create_wallet(name="MyAgent")` → `wallet_create(agent_name="MyAgent")`
   - `get_balance(wallet["address"])` → `wallet_balance(wallet_id="MyAgent")`
   - These match the actual tool names documented in the *Available Tools* section below

2. **Wrong function name in agent communication example**
   - `send_message(...)` → `beacon_send_message(...)`
   - Matches the actual documented tool name

3. **Outdated BoTTube video count**
   - Header said **850+** videos, but other parts of the README (Acknowledgments/skills) reference **1,050+**
   - Updated to **1,050+** for consistency

### Why This Matters

Agents copying the examples from README will get import errors if they use `create_wallet` instead of `wallet_create`. These fixes ensure all code examples use the real module API.

### Bounty

Related to: [EASY BOUNTY: 2 RTC] Fix a typo or improve docs in any Elyan Labs repo (#2178)
Related to: [EASY BOUNTY: 3 RTC] Add a README badge to your GitHub profile mentioning RustChain (#2177)

**RTC Wallet Address**: `236e22e007d3b8d5266e087d162c6dad22b522RTC`
