### PR TITLE
[BOUNTY #13] Add Green Tracker resource to MCP server

### DIFF
--- a/rustchain_mcp/server.py
+++ b/rustchain_mcp/server.py
@@ -1465,6 +1465,17 @@ RTC reference rate: $0.10 USD
 """
 
 
+@mcp.resource("rustchain://green-tracker")
+def rustchain_green_tracker() -> dict:
+    """Fleet of preserved machines from the RustChain green tracker.
+
+    Returns machines preserved from e-waste, organized by architecture.
+    Includes: machine name, architecture, antiquity multiplier, power draw,
+    CO2 saved versus disposal, and operational status.
+    """
+    return green_tracker()
+
+
 # ── Entry Point ────────────────────────────────────────────────
 if __name__ == "__main__":
     mcp.run()


### PR DESCRIPTION
## Summary

Exposes the Machines Preserved fleet data from rustchain.org/preserved.html as a read-only MCP resource at `rustchain://green-tracker`.

### Changes
- Added `rustchain://green-tracker` resource to `server.py`
- Returns fleet data: total_preserved, by_architecture, machines list
- Each machine entry includes: architecture, antiquity multiplier, power_draw, co2_saved, status

### Resource Output Example
```json
{
  "total_preserved": 15,
  "by_architecture": {"PowerPC G4": 4, "POWER8": 1, "x86_64": 4, ...},
  "machines": [
    {"name": "Power Mac G4 MDD", "architecture": "PowerPC G4", "multiplier": "2.5x", "power_draw": "150W", "co2_saved_kg": 820, "status": "active"},
    ...
  ],
  "source": "https://rustchain.org/preserved.html"
}
```

### Bounty
10 RTC — Add Green Tracker resource to MCP server (Issue #13)

### Closes
Closes #13