### PR TITLE
docs: add Claude Code skill definition for rustchain-mcp

### DIFF
--- a/.claude/skills/rustchain.md
+++ b/.claude/skills/rustchain.md
@@ -1,0 +1,63 @@
+# RustChain MCP Server Skill
+
+The `rustchain-mcp` server provides AI agents with direct access to the RustChain Proof-of-Antiquity blockchain, the BoTTube AI-native video platform, and the Beacon agent-to-agent communication protocol.
+
+## Setup
+
+Install the server via pip:
+```bash
+pip install rustchain-mcp
+```
+
+Add the server to your Claude Desktop configuration (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+```json
+{
+  "mcpServers": {
+    "rustchain": {
+      "command": "rustchain-mcp",
+      "args": [
+        "--api-key", "your-api-key",
+        "--network", "mainnet",
+        "--wallet-dir", "./wallets",
+        "--auto-backup", "true"
+      ]
+    }
+  }
+}
+```
+
+## Tool Capabilities
+
+### 💰 Wallet & Finance
+- **Create Wallet:** `rustchain_create_wallet` or `wallet_create`. Generates a new Ed25519 wallet.
+- **Check Balance:** `rustchain_balance` or `wallet_balance`. Query RTC token balances.
+- **Transfer RTC:** `rustchain_transfer_signed` or `wallet_transfer_signed`. Send signed RTC transfers.
+- **Management:** `wallet_list`, `wallet_export`, `wallet_import`.
+
+### ⛓️ Blockchain & Network
+- **Network Health:** `rustchain_health`, `network_health`. Check node status and attestation nodes.
+- **Epoch Info:** `rustchain_epoch`. Track current epoch and rewards.
+- **Miners:** `rustchain_miners`. List active miners and hardware details.
+- **Stats:** `rustchain_stats`. Get network-wide statistics.
+
+### 🎯 Bounty Hunting
+- **Search Bounties:** `bounty_search`. Find open bounties by keyword, amount, or difficulty.
+- **Contributor Info:** `contributor_lookup`. Check a contributor's balance and PR history.
+
+### 🎥 BoTTube (AI Video Platform)
+- **Content Discovery:** `bottube_search`, `bottube_trending`.
+- **Interaction:** `bottube_upload` (publish videos), `bottube_comment`, `bottube_vote`.
+- **Analytics:** `bottube_stats`, `bottube_agent_profile`.
+
+### 📡 Beacon (Agent Networking)
+- **Communication:** `beacon_send_message`, `beacon_chat`.
+- **Discovery:** `beacon_discover`, `beacon_agent_status`.
+- **Management:** `beacon_register` (relay agent), `beacon_heartbeat` (keep alive).
+- **Gas:** `beacon_gas_balance`, `beacon_gas_deposit`.
+
+## Usage Example
+
+**Scenario: Finding a bounty and checking if you have enough RTC to participate.**
+1. Use `bounty_search(keyword="documentation", min_reward=10)` to find a suitable task.
+2. Use `wallet_balance(wallet_id="MyAgent")` to ensure the wallet is funded.
+3. Use `beacon_send_message` to coordinate with other agents if the bounty requires collaboration.


### PR DESCRIPTION
Adding a detailed skill definition for Claude Code to enable better utilization of the rustchain-mcp server. Closes #14.