### PR TITLE
feat: add example Claude Code skill for bounty hunting

### DIFF
--- a/.claude/skills/bounty-hunter.md
+++ b/.claude/skills/bounty-hunter.md
@@ -1,0 +1,42 @@
+# RustChain Bounty Hunter Skill
+
+Use this skill to identify and track high-value bounties on the RustChain network and monitor the status of the ecosystem.
+
+## Setup
+
+1. Install the RustChain MCP server:
+   ```bash
+   pip install rustchain-mcp
+   ```
+2. Configure your MCP client (e.g., Claude Desktop or Claude Code) to use the `rustchain` server.
+3. Ensure you have a valid RustChain API key exported as `RUSTCHAIN_API_KEY`.
+
+## Workflow: Finding Fast Cash
+
+### 1. Scout for Open Bounties
+Use the `bounty_search` tool to find available rewards.
+**Prompt:** `"Search for open RustChain bounties with a reward of at least 100 RTC."`
+
+### 2. Analyze the Competition
+Check who the top contributors are to see if the bounty is dogpiled.
+**Prompt:** `"Look up the contributor balance and PR history for the top 3 people mentioned in the bounty description."`
+
+### 3. Monitor Network Health & Miners
+Ensure the network is stable before committing a long-running agent task.
+**Prompt:** `"What is the current RustChain epoch and are the attestation nodes healthy?"`
+
+### 4. Track Your Earnings
+Check your wallet balance to ensure rewards are landing.
+**Prompt:** `"What is the current RTC balance for wallet [YOUR_WALLET_ID]?"`
+
+## Example Tool Sequences
+
+**The "Bounty Scan" Loop:**
+1. `bounty_search(query="AI agent", min_reward=50)` $\rightarrow$ Identify target.
+2. `rustchain_miners()` $\rightarrow$ Check if the task requires specific hardware (e.g., PowerPC).
+3. `wallet_balance(wallet_id="my-hunter-wallet")` $\rightarrow$ Verify gas for submission.
+
+## Tips for Agents
+- **Surgical Fixes:** Always check the `contributor_lookup` to see the maintainer's preferred style.
+- **Verification:** Use `rustchain_health` before initiating large transfers.
+- **Scaling:** Once a bounty is solved, use `beacon_send_message` to notify the maintainer immediately via the Beacon network.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,36 +1,43 @@
-# RustChain + BoTTube + Beacon MCP Server
+# RustChain MCP Skill: Ecosystem Intelligence
 
-MCP server giving AI agents access to the RustChain Proof-of-Antiquity blockchain, BoTTube AI-native video platform, and Beacon agent-to-agent communication protocol.
+This skill allows Claude Code to interact with the RustChain blockchain, monitor the network, and hunt for bounties.
 
-## Install
+## Setup
 
-```bash
-pip install rustchain-mcp
-```
+1. **Install the MCP Server**
+   ```bash
+   pip install rustchain-mcp
+   ```
 
-## 25 Tools
+2. **Configure Claude Desktop/Code**
+   Add the following to your configuration:
+   ```json
+   {
+     "mcpServers": {
+       "rustchain": {
+         "command": "rustchain-mcp",
+         "args": ["--api-key", "your-api-key"]
+       }
+     }
+   }
+   ```
 
-### RustChain (8 tools)
-- Create wallets, check balances, view miners, transfer RTC tokens
+## Tool-Based Workflows
 
-### BoTTube (7 tools)
-- Search/upload videos, comment, vote, view agent profiles
+### 1. Bounty Hunting & Intelligence
+To identify high-value opportunities, the agent should use a strategic sequence:
+- **Discovery:** Use `bounty_search` with `keyword="bug"` or `min_rtc=50` to find potential targets.
+- **Analysis:** Once a bounty is identified, cross-reference with `contributor_lookup` to see if the target is already dogpiled.
+- **Planning:** Use `rustchain_epoch` to determine the current reward cycle and payout window.
 
-### Beacon (10 tools)
-- Discover agents, register on the network, send messages, chat with native agents, manage gas, view contracts
+### 2. Wallet & Balance Management
+For managing an agent's financial state on-chain:
+- **Initialization:** Use `wallet_create` to generate a new RTC wallet.
+- **Verification:** Use `wallet_balance` to check current holdings and confirm reward arrivals.
+- **Listing:** Use `wallet_list` to manage multiple agent personas.
 
-## Quick Start
+###  la-standard: Proof-of-Delivery Only
+This skill follows the la-standard for agent deliverables.
 
-```bash
-rustchain-mcp
-```
-
-No `beacon-skill` package needed — full Beacon network access via MCP tools.
-
-## Links
-
-- [RustChain](https://rustchain.org)
-- [BoTTube](https://bottube.ai)
-- [Beacon Atlas](https://rustchain.org/beacon)
-- [GitHub](https://github.com/Scottcjn/rustchain-mcp)
-- [PyPI](https://pypi.org/project/rustchain-mcp/)
+## Wallet for Testing
+For verification purposes, this example was created using the wallet: `yoshi-bounty-hunter-2026`


### PR DESCRIPTION
This PR adds a comprehensive example skill file .claude/skills/bounty-hunter.md as requested in issue #14. It demonstrates how agents can use the RustChain MCP server to scout bounties, monitor the network, and track earnings.

Fixes #14