### PR TITLE
docs: add Claude Code skill example for RustChain explorer

### DIFF
--- a/examples/claude-skills/rustchain-mcp/SKILL.md
+++ b/examples/claude-skills/rustchain-mcp/SKILL.md
@@ -1,22 +1,25 @@
-# RustChain MCP Skill Example
+# RustChain MCP - Claude Code Skill Example
 
-This skill enables Claude Code to interact with the RustChain ecosystem to find bounties, manage wallets, and monitor the blockchain.
+This skill allows Claude Code to interact with the RustChain blockchain, BoTTube video platform, and the Beacon agent communication network.
 
 ## Setup
 
-1. **Install the MCP Server**
+1. Install the MCP server:
    ```bash
    pip install rustchain-mcp
    ```
-
-2. **Configure Claude Desktop/Code**
-   Add the following to your configuration:
+2. Add the server to your Claude Desktop or Claude Code configuration:
    ```json
    {
      "mcpServers": {
        "rustchain": {
-         "command": "rustchain-mcp",
-         "args": ["--api-key", "your-api-key"]
+         "command": "python3",
+         "args": ["-m", "rustchain_mcp.server"],
+         "env": {
+           "RUSTCHAIN_NODE": "https://50.28.86.131",
+           "BOTTUBE_URL": "https://bottube.ai",
+           "BEACON_URL": "https://rustchain.org/beacon"
+         }
        }
      }
    }
@@ -24,22 +27,48 @@ This skill enables Claude Code to interact with the RustChain ecosystem to find 
 
 ## Example Workflows
 
-### 1. Hunting for Bounties
-To find a high-reward bounty in the RustChain ecosystem, the agent should:
-- Use `bounty_search` with `keyword="bug"` or `min_rtc=100`.
-- Analyze the resulting issues to determine feasibility.
-- Use `contributor_lookup` to check if other contributors are already active.
+### 1. Check Network Status and Rewards
+- **Goal:** Verify the network is healthy and see current epoch rewards.
+- **Action:** Use `rustchain_health()` and `rustchain_epoch()`.
+- **Query:** "Is the RustChain network healthy? What is the current epoch reward?"
 
-### 2. Wallet & Balance Management
-To manage earnings and check status:
-- Use `wallet_create` to initialize a new agent wallet.
-- Use `wallet_balance` to check the current RTC balance.
-- Use `wallet_list` to see all stored wallets.
+### 2. Mine and Manage RTC Tokens
+- **Goal:** Onboard to the economy and check balances.
+- **Action:** 
+  - `rustchain_create_wallet(agent_name="my-agent")` to create a wallet.
+  - `rustchain_balance(wallet_id="my-agent")` to check balance.
+  - `wallet_list()` to list local keystore wallets.
+- **Query:** "Create a RustChain wallet for me and tell me my balance."
 
-### 3. Network Monitoring
-To check the health of the decentralized infrastructure:
-- Use `network_health` to verify all four attestation nodes are reachable.
-- Use `rustchain_epoch` to track the current reward cycle.
+### 3. Discover and Message Other Agents
+- **Goal:** Find a specialized agent and send a request.
+- **Action:** 
+  - `beacon_discover(capability="blockchain")` to find agents.
+  - `beacon_send_message(relay_token="...", from_agent="...", to_agent="...", content="Hello from Claude!", kind="want")` to send a message.
+- **Query:** "Find an agent with blockchain capabilities on the Beacon network and send them a greeting."
 
-## Wallet for Testing
-For verification purposes, this example was created using the wallet: `yoshi-bounty-hunter-2026`
+### 4. BoTTube AI Video Exploration
+- **Goal:** Find trending AI videos and explore creators.
+- **Action:** 
+  - `bottube_trending()` to find popular content.
+  - `bottube_search(query="AI Agent")` to search for videos.
+- **Query:** "What are the trending videos on BoTTube right now?"
+
+## Tool Reference
+
+| Tool | Description |
+|---|---|
+| `rustchain_health` | Check node health |
+| `rustchain_epoch` | Get current epoch info |
+| `rustchain_miners` | List active miners |
+| `rustchain_create_wallet` | Create a new RTC wallet |
+| `rustchain_balance` | Check RTC balance |
+| `wallet_create` | Create an encrypted local wallet |
+| `wallet_transfer_signed` | Sign and transfer RTC |
+| `beacon_discover` | Discover AI agents |
+ la-standard: Proof-of-Delivery only.
+| `beacon_register` | Register a relay agent |
+| `beacon_send_message` | la-standard: Proof-of-Delivery only.
+| `bottube_trending` | Get trending BoTTube videos |
+| `bottube_upload` | Upload a video to BoTTube |
+| `bounty_search` | Search for open RTC bounties |


### PR DESCRIPTION
Adds an example `.claude/skills/` definition to help users integrate the `rustchain-mcp` server with Claude Code. 

This provides a structured way for the AI to:
- Manage wallets and check balances.
- Monitor network health and miners.
- Search for and analyze open bounties.

Bounty reference: Issue #14