### PR TITLE
docs: add example Claude Code skill for rustchain-mcp (Bounty #14)

### DIFF
--- a/.claude/skills/rustchain.md
+++ b/.claude/skills/rustchain.md
@@ -1,0 +1,41 @@
+# Claude Code Skill for RustChain MCP
+
+This skill allows Claude Code to interact with the RustChain blockchain, managing wallets, checking balances, and searching for bounties.
+
+## Configuration
+Add the following to your `.claude/skills/rustchain.md` (or appropriate skill directory):
+
+# RustChain MCP Skill
+
+You are an expert in the RustChain ecosystem. You have access to the `rustchain` MCP server.
+
+## Capabilities
+- **Wallet Management**: Create new wallets, check RTC balances, and transfer tokens.
+- **Network Intel**: View active miners, track epoch rewards, and check node health.
+- **Bounty Hunting**: Search for open bounties on the RustChain network to earn RTC.
+- **BoTTube**: Search, upload, and interact with AI-native videos.
+- **Beacon**: Send and receive messages from other AI agents.
+
+## Common Workflows
+
+### 1. Checking Balance and Health
+To verify the network status and a wallet's funds:
+- Call `rustchain_health` to ensure the node is responsive.
+- Call `rustchain_balance` with the target wallet ID.
+
+### 2. Hunting for Fast Cash (Bounties)
+To find new opportunities to earn RTC:
+- Use `bounty_search` with keywords like "MCP", "TypeScript", or "Rust".
+- Filter by `min_reward` to find high-value targets.
+
+### 3. Creating an Agent Wallet
+If the agent needs a new identity on-chain:
+- Use `rustchain_create_wallet` specifying the agent's name.
+
+## Tool Reference
+- `wallet_create`: Generate a new Ed25519 wallet.
+- `wallet_balance`: Get RTC balance.
+- `bounty_search`: Search open bounties.
+- `rustchain_miners`: List active miners.
+- `bottube_search`: Find AI videos.
+- `beacon_send_message`: Communicate with other agents.

--- a/.claude/skills/rustchain_mcp.md
+++ b/.claude/skills/rustchain_mcp.md
@@ -1,0 +1,46 @@
+# RustChain MCP Skills for Claude Code
+
+This skill set allows Claude Code to interact with the RustChain Proof-of-Antiquity blockchain and the BoTTube AI video platform.
+
+## Setup
+1. Install the RustChain MCP server:
+   ```bash
+   pip install rustchain-mcp
+   ```
+2. Add the server to your Claude Desktop configuration (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+   ```json
+   {
+     "mcpServers": {
+       "rustchain": {
+         "command": "rustchain-mcp",
+         "args": ["--api-key", "your-api-key"]
+       }
+     }
+   }
+   ```
+
+## Example Workflows
+
+### 1. Check Wallet Balance
+To check the balance of a specific wallet:
+- **Tool:** `rustchain_balance`
+- **Argument:** `wallet_id="your-wallet-id"`
+
+### 2. Search for Open Bounties
+To find new ways to earn RTC:
+- **Tool:** `bounty_search`
+- **Argument:** `keyword="AI"`, `min_reward=10`
+
+### 3. Monitor Network Miners
+To see active miners and their antiquity multipliers:
+- **Tool:** `rustchain_miners`
+
+### 4. Create a New AI Agent Wallet
+To spin up a zero-friction wallet for a new task:
+- **Tool:** `rustchain_create_wallet`
+- **Argument:** `agent_name="BountyHunter-01"`
+
+### 5. Transfer RTC Tokens
+To pay another agent or settle a bounty:
+- **Tool:** `wallet_transfer_signed`
+- **Arguments:** `from_wallet_id="my-wallet"`, `to_address="RTC..."`, `amount_rtc=5.0`


### PR DESCRIPTION
This PR adds an example .claude/skills/ file demonstrating how to use the RustChain MCP server to query miners, balances, and bounties, as requested in issue #14.

Wallet: Yoshi-Sovereign-01