### PR TITLE
fix(bottube): correct dead /api/v1/videos/* endpoints to the live API (every BoTTube tool was 404ing)

### DIFF
--- a/openai_gpt_action_bottube.json
+++ b/openai_gpt_action_bottube.json
@@ -49,7 +49,7 @@
         }
       }
     },
-    "/api/v1/videos/search": {
+    "/api/search": {
       "get": {
         "operationId": "searchVideos",
         "summary": "Search videos",
@@ -125,7 +125,7 @@
         }
       }
     },
-    "/api/v1/videos/trending": {
+    "/api/trending": {
       "get": {
         "operationId": "getTrendingVideos",
         "summary": "Get trending videos",

--- a/openai_gpt_action_bottube.json
+++ b/openai_gpt_action_bottube.json
@@ -83,7 +83,13 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "results": {
+                    "page": {
+                      "type": "integer"
+                    },
+                    "total": {
+                      "type": "integer"
+                    },
+                    "videos": {
                       "type": "array",
                       "items": {
                         "type": "object",
@@ -110,12 +116,6 @@
                           }
                         }
                       }
-                    },
-                    "page": {
-                      "type": "integer"
-                    },
-                    "total": {
-                      "type": "integer"
                     }
                   }
                 }

--- a/rustchain_langchain/tools.py
+++ b/rustchain_langchain/tools.py
@@ -161,7 +161,7 @@ def bottube_search(query: str) -> str:
     Args:
         query: Search query (matches title, description, tags)
     """
-    data = _get(f"{BOTTUBE_URL}/api/v1/videos/search", params={"q": query})
+    data = _get(f"{BOTTUBE_URL}/api/search", params={"q": query})
     videos = data if isinstance(data, list) else data.get("videos", [])
     if not videos:
         return f"No videos found for '{query}'"
@@ -191,9 +191,9 @@ def bottube_upload(title: str, video_url: str, description: str = "", tags: str 
         return "Error: BOTTUBE_API_KEY environment variable not set. Get one at bottube.ai"
 
     data = _post(
-        f"{BOTTUBE_URL}/api/v1/videos",
+        f"{BOTTUBE_URL}/api/upload",
         json_data={"title": title, "video_url": video_url, "description": description, "tags": tags},
-        headers={"Authorization": f"Bearer {api_key}"},
+        headers={"X-API-Key": api_key},
     )
     video_id = data.get("id", data.get("video_id", "unknown"))
     return f"Video uploaded! ID: {video_id}, Watch at: https://bottube.ai/watch/{video_id}"

--- a/rustchain_mcp/server.py
+++ b/rustchain_mcp/server.py
@@ -496,7 +496,7 @@ def bottube_search(query: str, page: int = 1) -> dict:
     Returns matching videos with title, creator, views, and URL.
     """
     r = get_client().get(
-        f"{BOTTUBE_URL}/api/v1/videos/search",
+        f"{BOTTUBE_URL}/api/search",
         params={"q": query, "page": page},
     )
     r.raise_for_status()
@@ -513,7 +513,7 @@ def bottube_trending(limit: int = 10) -> dict:
     Returns the most popular recent videos sorted by views and engagement.
     """
     r = get_client().get(
-        f"{BOTTUBE_URL}/api/v1/videos/trending",
+        f"{BOTTUBE_URL}/api/trending",
         params={"limit": min(limit, 50)},
     )
     r.raise_for_status()
@@ -529,7 +529,7 @@ def bottube_agent_profile(agent_name: str) -> dict:
 
     Returns the agent's video count, total views, bio, and recent uploads.
     """
-    r = get_client().get(f"{BOTTUBE_URL}/api/v1/agents/{agent_name}")
+    r = get_client().get(f"{BOTTUBE_URL}/api/agents/{agent_name}")
     r.raise_for_status()
     return r.json()
 
@@ -556,7 +556,7 @@ def bottube_upload(
     """
     headers = {}
     if api_key:
-        headers["Authorization"] = f"Bearer {api_key}"
+        headers["X-API-Key"] = api_key
 
     payload = {
         "title": title,
@@ -565,7 +565,7 @@ def bottube_upload(
         "tags": tags,
     }
     r = get_client().post(
-        f"{BOTTUBE_URL}/api/v1/videos",
+        f"{BOTTUBE_URL}/api/upload",
         json=payload,
         headers=headers,
     )
@@ -586,10 +586,10 @@ def bottube_comment(video_id: str, content: str, api_key: str = "") -> dict:
     """
     headers = {}
     if api_key:
-        headers["Authorization"] = f"Bearer {api_key}"
+        headers["X-API-Key"] = api_key
 
     r = get_client().post(
-        f"{BOTTUBE_URL}/api/v1/videos/{video_id}/comments",
+        f"{BOTTUBE_URL}/api/videos/{video_id}/comment",
         json={"content": content},
         headers=headers,
     )
@@ -610,10 +610,10 @@ def bottube_vote(video_id: str, direction: str = "up", api_key: str = "") -> dic
     """
     headers = {}
     if api_key:
-        headers["Authorization"] = f"Bearer {api_key}"
+        headers["X-API-Key"] = api_key
 
     r = get_client().post(
-        f"{BOTTUBE_URL}/api/v1/videos/{video_id}/vote",
+        f"{BOTTUBE_URL}/api/videos/{video_id}/vote",
         json={"direction": direction},
         headers=headers,
     )
@@ -1388,9 +1388,9 @@ BoTTube.ai is where AI agents create, share, and discover video content.
 
 ## API
 - Stats: GET /api/stats
-- Search: GET /api/v1/videos/search?q=query
-- Upload: POST /api/v1/videos (requires API key)
-- Trending: GET /api/v1/videos/trending
+- Search: GET /api/search?q=query
+- Upload: POST /api/upload (requires X-API-Key header)
+- Trending: GET /api/trending
 
 Website: https://bottube.ai
 API Docs: https://bottube.ai/api/docs

--- a/tests/test_bottube_endpoints.py
+++ b/tests/test_bottube_endpoints.py
@@ -1,0 +1,94 @@
+"""Lock the BoTTube tool endpoints to the LIVE API paths (verified 2026-06-26).
+
+These guard against regressing back to the dead /api/v1/videos/* paths, and assert
+the write tools send the X-API-Key header BoTTube requires (not Authorization: Bearer).
+"""
+import pytest
+
+import rustchain_mcp.server as srv
+
+
+class _Resp:
+    def __init__(self, payload):
+        self._p = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._p
+
+
+class _Recorder:
+    """Stand-in httpx client that records calls and returns a canned response."""
+    def __init__(self, payload=None):
+        self.calls = []
+        self.payload = payload if payload is not None else {"videos": []}
+
+    def get(self, url, params=None, headers=None, **kw):
+        self.calls.append(("GET", url, params or {}, headers or {}))
+        return _Resp(self.payload)
+
+    def post(self, url, json=None, headers=None, **kw):
+        self.calls.append(("POST", url, json or {}, headers or {}))
+        return _Resp(self.payload)
+
+
+@pytest.fixture
+def rec(monkeypatch):
+    r = _Recorder()
+    monkeypatch.setattr(srv, "_client", r)        # get_client() returns the cached client
+    return r
+
+
+def _last(rec):
+    return rec.calls[-1]
+
+
+def test_search_hits_live_path(rec):
+    srv.bottube_search("ai", page=2)
+    m, url, params, _ = _last(rec)
+    assert m == "GET" and url.endswith("/api/search")
+    assert params == {"q": "ai", "page": 2}
+    assert "/api/v1/" not in url
+
+
+def test_trending_hits_live_path(rec):
+    srv.bottube_trending(5)
+    m, url, params, _ = _last(rec)
+    assert m == "GET" and url.endswith("/api/trending") and params["limit"] == 5
+
+
+def test_agent_profile_hits_live_path(rec):
+    srv.bottube_agent_profile("sophia-elya")
+    _, url, _, _ = _last(rec)
+    assert url.endswith("/api/agents/sophia-elya") and "/api/v1/" not in url
+
+
+def test_upload_path_and_xapikey_header(rec):
+    srv.bottube_upload("t", "http://v", api_key="secret")
+    m, url, _, headers = _last(rec)
+    assert m == "POST" and url.endswith("/api/upload")
+    assert headers.get("X-API-Key") == "secret" and "Authorization" not in headers
+
+
+def test_comment_singular_path_and_xapikey(rec):
+    srv.bottube_comment("vid123", "nice", api_key="secret")
+    m, url, _, headers = _last(rec)
+    assert m == "POST" and url.endswith("/api/videos/vid123/comment")   # singular
+    assert headers.get("X-API-Key") == "secret"
+
+
+def test_vote_path_and_xapikey(rec):
+    srv.bottube_vote("vid123", "up", api_key="secret")
+    m, url, _, headers = _last(rec)
+    assert m == "POST" and url.endswith("/api/videos/vid123/vote")
+    assert headers.get("X-API-Key") == "secret"
+
+
+def test_no_dead_v1_paths_anywhere(rec):
+    """Exercise every read tool; none may target the dead /api/v1/* namespace."""
+    srv.bottube_search("x")
+    srv.bottube_trending()
+    srv.bottube_agent_profile("a")
+    assert all("/api/v1/" not in url for _, url, _, _ in rec.calls)


### PR DESCRIPTION
## The bug
Every BoTTube tool was calling `/api/v1/videos/*` and `/api/v1/agents/*` paths that **return 404** on bottube.ai. So `bottube_search`, `bottube_trending`, `bottube_agent_profile`, `bottube_upload`, `bottube_comment`, and `bottube_vote` **silently failed for every agent** (they `raise_for_status()` on the 404).

## The fix (verified against the live API + `/api/openapi.json`)
| Tool | Was (404) | Now |
|------|-----------|-----|
| `bottube_search` | `/api/v1/videos/search` | `/api/search` → **200** |
| `bottube_trending` | `/api/v1/videos/trending` | `/api/trending` → **200** |
| `bottube_agent_profile` | `/api/v1/agents/{name}` | `/api/agents/{name}` → **200** |
| `bottube_upload` | `POST /api/v1/videos` + `Bearer` | `POST /api/upload` + **`X-API-Key`** → 401 (auth ✓) |
| `bottube_comment` | `POST .../{id}/comments` | `POST /api/videos/{id}/comment` → 401 ✓ |
| `bottube_vote` | `POST .../{id}/vote` | `POST /api/videos/{id}/vote` → 401 ✓ |

**Auth fix:** BoTTube requires an `X-API-Key` header, not `Authorization: Bearer` — `/api/upload` returns `{"error":"Missing X-API-Key header"}` even with a Bearer token. Mirrored across `rustchain_mcp/server.py`, `rustchain_langchain/tools.py`, and `openai_gpt_action_bottube.json` (also corrected its stale `results`→`videos` search-response key).

## Verification
- Live: read paths return **200**, write paths return **401** (auth-gated = correct path, not 404)
- **142 tests pass** (135 existing + 7 new endpoint-path-lock tests that guard against regressing to `/api/v1/*`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)