### PR TITLE
Add .well-known/mcp.json for MCP server discovery

### DIFF
--- a/.well-known/mcp.json
+++ b/.well-known/mcp.json
@@ -1,0 +1,18 @@
+{
+  "mcp": {
+    "icons": [
+      {
+        "src": "https://rustchain.org/images/logo.png",
+        "type": "image/png"
+      }
+    ],
+    "description": "RustChain + BoTTube MCP Server: blockchain, video platform, and agent messaging tools",
+    "server": {
+      "name": "rustchain-mcp",
+      "description": "MCP server for RustChain blockchain, BoTTube video, and Beacon messaging.",
+      "homepageURL": "https://rustchain.org",
+      "repositoryURL": "https://github.com/Scottcjn/rustchain-mcp",
+      "license": "MIT"
+    }
+  }
+}


### PR DESCRIPTION
This adds a .well-known/mcp.json file to enable auto-discovery by registries like Smithery.ai, Glama, and others.