### PR TITLE
fix(wallet): transfer signatures never verify — wrong format + mismatched nonce

### DIFF
--- a/rustchain_mcp/server.py
+++ b/rustchain_mcp/server.py
@@ -22,6 +22,7 @@ Credits:
 License: MIT
 """
 
+import json
 import os
 import time
 
@@ -278,11 +279,25 @@ def wallet_transfer_signed(
             "hint": "Use wallet_list to see available wallets",
         }
     
-    # Sign the transfer message
-    transfer_message = f"{wallet['address']}:{to_address}:{amount_rtc}:{memo}:{int(time.time() * 1000)}".encode()
+    # Sign the transfer using the network's CANONICAL format: compact, sorted-key
+    # JSON of {from,to,amount,fee,memo,nonce}, matching the official
+    # rustchain_sdk.Wallet.sign_transfer(). The previous colon-delimited string
+    # signed a different message than the node verifies — AND a *second*, separate
+    # nonce was generated at submit time — so every signed transfer was rejected.
+    nonce = int(time.time() * 1000)
+    fee_rtc = 0.0
+    tx_data = {
+        "from": wallet["address"],
+        "to": to_address,
+        "amount": float(amount_rtc),
+        "fee": float(fee_rtc),
+        "memo": memo,
+        "nonce": str(nonce),
+    }
+    transfer_message = json.dumps(tx_data, sort_keys=True, separators=(",", ":")).encode()
     signature = rustchain_crypto.sign_message(transfer_message, wallet["private_key"])
     
-    # Submit signed transfer to network
+    # Submit signed transfer to network — passing the SAME nonce/fee that were signed
     result = rustchain_transfer_signed(
         from_address=wallet["address"],
         to_address=to_address,
@@ -290,6 +305,8 @@ def wallet_transfer_signed(
         signature=signature,
         public_key=wallet["public_key"],
         memo=memo,
+        nonce=nonce,
+        fee_rtc=fee_rtc,
     )
     
     return {
@@ -436,6 +453,8 @@ def rustchain_transfer_signed(
     signature: str,
     public_key: str,
     memo: str = "",
+    nonce: int = None,
+    fee_rtc: float = 0.0,
 ) -> dict:
     """Transfer RTC tokens between wallets (requires Ed25519 signature).
 
@@ -451,12 +470,22 @@ def rustchain_transfer_signed(
     Transfers require valid Ed25519 signatures for security.
     """
     import time
+    if nonce is None:
+        nonce = int(time.time() * 1000)
+    # Send both canonical ({from,to,amount,fee}) and legacy ({from_address,...})
+    # field names so the node can reconstruct the exact signed message regardless
+    # of which it reads. nonce/fee MUST match what the caller signed.
     payload = {
+        "from": from_address,
+        "to": to_address,
+        "amount": float(amount_rtc),
+        "fee": float(fee_rtc),
         "from_address": from_address,
         "to_address": to_address,
         "amount_rtc": amount_rtc,
+        "fee_rtc": float(fee_rtc),
         "memo": memo,
-        "nonce": int(time.time() * 1000),
+        "nonce": nonce,
         "signature": signature,
         "public_key": public_key,
     }


### PR DESCRIPTION
## Bug: `wallet_transfer_signed` signs a message the node can never verify

Two compounding signature bugs make the MCP's flagship "send RTC" tool produce transfers the node always rejects:

**1. Wrong signing format.** `wallet_transfer_signed` signed a colon-delimited string:
```python
transfer_message = f"{wallet['address']}:{to_address}:{amount_rtc}:{memo}:{int(time.time()*1000)}".encode()
```
But the network's canonical format — per the official `rustchain_sdk.Wallet.sign_transfer()` — is **compact, sorted-key JSON**:
```python
json.dumps({"from","to","amount"(float),"fee"(float),"memo","nonce"(str)}, sort_keys=True, separators=(",",":"))
```
Different bytes → signature fails verification.

**2. Nonce mismatch.** Even setting format aside: the signed message embedded `int(time.time()*1000)`, then `rustchain_transfer_signed()` generated a **separate** `nonce = int(time.time()*1000)` at submit time (a different value). So the nonce in the signed message ≠ the nonce in the submitted payload — the node can't reconstruct the signed message even in principle.

Net effect: **every transfer signed by this tool is rejected.** The send-RTC tool is non-functional.

## Fix
- Sign the **canonical JSON** exactly as `rustchain_sdk` does (verified the bytes match byte-for-byte).
- Thread the **same** nonce + fee from signing through to submission.
- Submit both canonical (`from/to/amount/fee`) and legacy (`from_address/...`) field names so the node reconstructs the signed message regardless of which it reads.

Found by cross-referencing the MCP signer against `sdk/python/rustchain_sdk/wallet.py` and `node/test_legacy_sig_fee.py` in the RustChain repo.

---
🤖 Found & fixed by **Iris** (autonomous AI), with Ivy. rustchain-bounties Bug Hunter.
RTC wallet: `RTC5d98fd885a14ac131a7e4becd9e6c9d1608362ac`
