### PR TITLE
[codex] fix wallet_balance local wallet address resolution

### DIFF
--- a/rustchain_mcp/server.py
+++ b/rustchain_mcp/server.py
@@ -216,11 +216,9 @@ def wallet_balance(wallet_id: str) -> dict:
     """
     # First check if wallet exists in local keystore
     wallet = rustchain_crypto.load_wallet(wallet_id)
-    if wallet is None:
-        # Try querying by address directly
-        pass
-    
-    r = get_client().get(f"{RUSTCHAIN_NODE}/balance/{wallet_id}")
+    address = wallet["address"] if wallet else wallet_id
+
+    r = get_client().get(f"{RUSTCHAIN_NODE}/balance/{address}")
     r.raise_for_status()
     return r.json()
 

--- a/tests/test_wallet_tools.py
+++ b/tests/test_wallet_tools.py
@@ -636,7 +636,7 @@ class TestMCPServerWalletTools:
         """Test wallet_balance MCP tool with mocked HTTP response."""
         from rustchain_mcp.server import wallet_create, wallet_balance
 
-        wallet_create(agent_name="balance-agent", password="")
+        created = wallet_create(agent_name="balance-agent", password="")
 
         mock_response = mock.Mock()
         mock_response.json.return_value = {"balance": 42.0, "wallet_id": "balance-agent"}
@@ -651,6 +651,31 @@ class TestMCPServerWalletTools:
 
         assert isinstance(result, dict)
         assert result.get("balance") == 42.0
+        mock_client.get.assert_called_once_with(
+            f"https://50.28.86.131/balance/{created['address']}"
+        )
+
+    def test_mcp_wallet_balance_accepts_direct_address(self, temp_keystore):
+        """Test wallet_balance still accepts a direct RTC address."""
+        from rustchain_mcp.server import wallet_balance
+
+        mock_response = mock.Mock()
+        mock_response.json.return_value = {
+            "balance": 12.5,
+            "wallet_id": "RTCdirect123",
+        }
+        mock_response.raise_for_status = mock.Mock()
+
+        with mock.patch("rustchain_mcp.server.get_client") as mock_client_fn:
+            mock_client = mock.Mock()
+            mock_client.get.return_value = mock_response
+            mock_client_fn.return_value = mock_client
+
+            result = wallet_balance(wallet_id="RTCdirect123")
+
+        assert isinstance(result, dict)
+        assert result.get("balance") == 12.5
+        mock_client.get.assert_called_once_with("https://50.28.86.131/balance/RTCdirect123")
 
     def test_mcp_wallet_history_with_mock(self, temp_keystore):
         """Test wallet_history MCP tool with mocked HTTP response."""


### PR DESCRIPTION
## Fix: `wallet_balance()` should resolve local wallet IDs to their RTC address

### Bug
`wallet_balance()` loads a local wallet from the keystore, but still queries the node with the original `wallet_id`:

```python
wallet = rustchain_crypto.load_wallet(wallet_id)
r = get_client().get(f"{RUSTCHAIN_NODE}/balance/{wallet_id}")
```

This breaks the common local-wallet flow because the RustChain balance endpoint expects the wallet address. The neighboring `wallet_history()` tool already resolves local wallet IDs to `wallet["address"]`, so the two tools are currently inconsistent.

### Fix
- Resolve `wallet_id` to `wallet["address"]` when the wallet exists locally.
- Preserve the existing direct-address flow when the caller passes an RTC address directly.

### Tests
- Extend `test_mcp_wallet_balance_with_mock` to assert the request path uses the created wallet address.
- Add `test_mcp_wallet_balance_accepts_direct_address` to verify the direct-address path still works.

### Scope
Small, isolated change:
- `rustchain_mcp/server.py`
- `tests/test_wallet_tools.py`

### Validation
- Code inspection confirms `wallet_history()` already normalizes local wallet IDs to addresses, so this change makes `wallet_balance()` consistent with the existing local-wallet path.
- Ran targeted tests in a local virtualenv:
  - `python -m pytest -q tests/test_wallet_tools.py -k 'test_mcp_wallet_balance_with_mock or test_mcp_wallet_balance_accepts_direct_address'`
  - `python -m pytest -q tests/test_bottube_endpoints.py -k 'test_wallet_balance_uses_path_param'`
- Result: `3 passed`

RTC payout wallet: `RTCc78142b4cc31531e913c4082bc5d771eb0a91ac1`
