### PR TITLE
[codex] fix README MCP Python entrypoint example

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,19 @@ Add to your Claude config file (`~/Library/Application Support/Claude/claude_des
 
 ### For Other MCP Clients
 
-```python
-from rustchain_mcp import RustChainMCPServer
+The package exposes the MCP server entrypoint via `rustchain_mcp.server`.
+Configure the node URLs with environment variables, then import and run `mcp`:
 
-server = RustChainMCPServer(api_key="your-api-key")
-server.run()
+```python
+import os
+
+os.environ["RUSTCHAIN_NODE"] = "https://50.28.86.131"
+os.environ["BOTTUBE_URL"] = "https://bottube.ai"
+os.environ["BEACON_URL"] = "https://rustchain.org/beacon"
+
+from rustchain_mcp.server import mcp
+
+mcp.run()
 ```
 
 ## Prerequisites


### PR DESCRIPTION
## Fix: README quick-start import path for Python MCP usage

Closes #250.

### Bug
The README currently documents this Python entrypoint:

```python
from rustchain_mcp import RustChainMCPServer

server = RustChainMCPServer(api_key="your-api-key")
server.run()
```

That symbol is not exported by the package, so following the quick-start example fails at import time.

### Fix
- Replace the broken example with the real package entrypoint: `from rustchain_mcp.server import mcp`
- Show the environment variables the server expects before calling `mcp.run()`

### Scope
Docs-only change in `README.md`.

### Validation
- Verified `rustchain_mcp/__init__.py` does not export `RustChainMCPServer`.
- Verified the MCP server entrypoint is defined in `rustchain_mcp/server.py` as `mcp = FastMCP(...)`.

RTC payout wallet: `RTCc78142b4cc31531e913c4082bc5d771eb0a91ac1`
