### PR TITLE
fix: make README programmatic example importable (closes #250)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,16 @@ Add to your Claude config file (`~/Library/Application Support/Claude/claude_des
 
 ### For Other MCP Clients
 
-```python
-from rustchain_mcp import RustChainMCPServer
+Any MCP-compatible client can launch the `rustchain-mcp` console script directly
+(same as the Claude Desktop config above). To embed or run the server
+programmatically, import the FastMCP server instance and run it:
 
-server = RustChainMCPServer(api_key="your-api-key")
-server.run()
+```python
+from rustchain_mcp import mcp
+
+# Configuration is read from environment variables (all optional):
+#   RUSTCHAIN_NODE, BOTTUBE_URL, BEACON_URL, RUSTCHAIN_TIMEOUT
+mcp.run()  # serves over stdio by default
 ```
 
 ## Prerequisites

--- a/rustchain_mcp/__init__.py
+++ b/rustchain_mcp/__init__.py
@@ -1,3 +1,12 @@
 """RustChain + BoTTube MCP Server — AI agent tools for the RustChain blockchain and BoTTube video platform."""
 
 __version__ = "0.4.0"
+
+# Re-export the FastMCP server instance so it can be used programmatically:
+#     from rustchain_mcp import mcp
+#     mcp.run()
+# This is the same object the ``rustchain-mcp`` console script runs
+# (see [project.scripts] in pyproject.toml -> rustchain_mcp.server:mcp.run).
+from .server import mcp
+
+__all__ = ["mcp", "__version__"]


### PR DESCRIPTION
## Summary
Fixes #250. The README quick-start "For Other MCP Clients" example was broken:

```python
from rustchain_mcp import RustChainMCPServer
server = RustChainMCPServer(api_key="your-api-key")
server.run()
```

There is no `RustChainMCPServer` symbol and no `api_key` constructor. `rustchain_mcp/__init__.py` exported only `__version__`, and the server is a module-level `FastMCP` instance in `rustchain_mcp/server.py` (`mcp = FastMCP(...)`) — the same object the `rustchain-mcp` console script runs (`[project.scripts]` → `rustchain_mcp.server:mcp.run`). So anyone following the documented Python example hit an `ImportError`.

## Fix
- **`rustchain_mcp/__init__.py`**: re-export the real server instance (`from .server import mcp`) so `from rustchain_mcp import mcp` works — this is the issue's suggested fix of "the package should export the documented symbol". `__version__` is preserved and `__all__` added.
- **`README.md`**: replace the non-existent class example with the working API:
  ```python
  from rustchain_mcp import mcp
  mcp.run()
  ```

## Verification
Fresh venv, `pip install fastmcp httpx`, package installed from this branch:

- **Before:** `from rustchain_mcp import RustChainMCPServer` → `ImportError`
- **After:** `from rustchain_mcp import mcp; mcp.run` imports cleanly (`type=FastMCP`, name `"RustChain + BoTTube + Beacon"`)
- `rustchain_mcp.__version__` still `0.4.0`; `__all__ == ['mcp', '__version__']`
- Console entry point unchanged (`rustchain_mcp.server:mcp.run` still resolvable and callable)

Docs-vs-code only; no tool behavior changed.

/claim #250
