### PR TITLE
fix(tls): preserve case of RUSTCHAIN_CA_BUNDLE path (.lower() broke custom CA bundles)

### DIFF
--- a/rustchain_mcp/server.py
+++ b/rustchain_mcp/server.py
@@ -50,13 +50,17 @@ mcp = FastMCP(
 )
 
 # TLS verification — secure by default, configurable for self-signed certs
-_TLS_VERIFY = os.environ.get("RUSTCHAIN_CA_BUNDLE",
-              os.environ.get("RUSTCHAIN_TLS_VERIFY", "true")).lower()
-if _TLS_VERIFY in ("false", "0", "no"):
+_TLS_RAW = os.environ.get("RUSTCHAIN_CA_BUNDLE",
+           os.environ.get("RUSTCHAIN_TLS_VERIFY", "true"))
+_TLS_NORM = _TLS_RAW.strip().lower()
+if _TLS_NORM in ("false", "0", "no"):
     _TLS_VERIFY = False
-elif _TLS_VERIFY == "true":
+elif _TLS_NORM in ("true", "1", "yes"):
     _TLS_VERIFY = True
-# else: treat as path to CA bundle
+else:
+    # treat as path to a CA bundle — keep the ORIGINAL case, since the
+    # filesystem is case-sensitive (lowercasing the path breaks lookups)
+    _TLS_VERIFY = _TLS_RAW.strip()
 
 # Shared HTTP client
 _client = None


### PR DESCRIPTION
## Problem

`RUSTCHAIN_CA_BUNDLE` is documented (and coded) to accept **a path to a custom CA bundle** for TLS verification against self-signed / private-CA nodes. But the raw env value is force-`.lower()`-ed before use:

```python
_TLS_VERIFY = os.environ.get("RUSTCHAIN_CA_BUNDLE",
              os.environ.get("RUSTCHAIN_TLS_VERIFY", "true")).lower()
...
# else: treat as path to CA bundle
```

The lowercased string is then handed to `httpx.Client(verify=_TLS_VERIFY)`. On any case-sensitive filesystem (i.e. all Linux), a real path with any uppercase character is corrupted:

```
RUSTCHAIN_CA_BUNDLE=/etc/ssl/MyCorp-Root.pem
  ->  verify="/etc/ssl/mycorp-root.pem"   # file does not exist
```

so `get_client()` fails at the first request with a file-not-found, and there is **no workaround** — the documented "point at your own CA bundle" feature is unusable for any path that isn't already all-lowercase.

### Reproduce
```
export RUSTCHAIN_CA_BUNDLE=/opt/CA/Rustchain.pem
python -c "import rustchain_mcp.server as s; s.rustchain_health()"
# -> httpx raises: could not load CA bundle '/opt/ca/rustchain.pem'
```

## Fix

Only lowercase a *copy* used for the boolean comparison; keep the original case when the value is a path. Also made the truthy branch symmetric with the falsy one (`1`/`yes` now accepted, matching `0`/`no`).

```python
_TLS_RAW = os.environ.get("RUSTCHAIN_CA_BUNDLE",
           os.environ.get("RUSTCHAIN_TLS_VERIFY", "true"))
_TLS_NORM = _TLS_RAW.strip().lower()
if _TLS_NORM in ("false", "0", "no"):
    _TLS_VERIFY = False
elif _TLS_NORM in ("true", "1", "yes"):
    _TLS_VERIFY = True
else:
    _TLS_VERIFY = _TLS_RAW.strip()   # path — preserve case
```

Boolean behavior is unchanged (`true`/`false` still parse the same, case-insensitively); only the path branch is fixed.

---
RTC: RTCd1554f0f35576faf01d386a6be1c947f560dd0b7