### PR TITLE
docs+test: document and pin down streaming/long-running tool behavior (closes #231)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 .eggs/
 *.egg
 .env
+.venv/

--- a/README.md
+++ b/README.md
@@ -282,6 +282,68 @@ export BEACON_MESSAGE_RETENTION="30d"
 }
 ```
 
+## Streaming & Long-Running Tools
+
+**Short answer (rustchain-mcp#231):** the server does **not** support SSE
+streaming or MCP `notifications/progress`. Every tool is a **synchronous,
+blocking** call: it awaits the full upstream HTTP response and returns a
+single completed JSON result. Long-running queries (e.g. `/api/miners` on a
+busy node) simply block until the response is ready, or until the request
+hits `RUSTCHAIN_TIMEOUT` (default 30s), at which point they return a
+structured error object instead of hanging.
+
+### What the code actually does
+
+- The server is built on `FastMCP` with plain `@mcp.tool()` functions
+  (`rustchain_mcp/server.py`). **None of the 37 registered tools accept a
+  `ctx`/`context` parameter**, so none can emit progress notifications —
+  FastMCP only reports progress when a tool takes a `Context` and calls
+  `ctx.report_progress(...)`.
+- All tools return a single `dict` (or list). **No tool is a generator or
+  async-generator**, i.e. none yield partial / streamed results.
+- `get_client()` returns one shared, **blocking** `httpx.Client`
+  (`timeout=RUSTCHAIN_TIMEOUT`, `verify=_TLS_VERIFY`). Tools call
+  `client.get(...)` / `client.post(...)` and block on the response.
+- The server advertises **no experimental streaming capability** —
+  `mcp.experimental_capabilities == {}`.
+
+### Capability flags advertised
+
+| Capability | Advertised? | Notes |
+|---|---|---|
+| `tools` | ✅ | All 37 tools |
+| `resources` / `prompts` | ✅ (FastMCP defaults) | Not used by this server |
+| `logging` | ❌ | Not enabled |
+| `progress` / streaming | ❌ | **Not implemented** — no `notifications/progress` is ever sent |
+
+### Behavior on a slow / long-running call
+
+| Phase | Behavior |
+|---|---|
+| Request in flight | Tool blocks; the caller waits for the full response |
+| Success | A single completed JSON result is returned |
+| Timeout (`RUSTCHAIN_TIMEOUT`) | `httpx.TimeoutException` → structured MCP error, **not** a hang |
+| Cancellation | Client-initiated abort stops waiting at the transport layer |
+
+### How to verify
+
+The contract above is enforced by tests in
+[`tests/test_streaming_contract.py`](tests/test_streaming_contract.py):
+
+- `test_no_tool_accepts_progress_context` — asserts no tool takes a progress `ctx`.
+- `test_no_tool_is_a_generator_or_async_generator` — asserts no tool streams.
+- `test_server_advertises_no_experimental_streaming_capability` — asserts
+  `experimental_capabilities == {}`.
+- `test_slow_tool_blocks_until_complete_and_returns_single_result` — a mocked
+  slow `GET /health` blocks the tool for the full delay and returns exactly one
+  completed result (no partial / progress output).
+
+If streaming or progress reporting is ever added, these tests fail — keeping
+the documentation honest.
+
+> See also [`docs/STREAMING_BEHAVIOR.md`](docs/STREAMING_BEHAVIOR.md) for the
+> full timeout / error / cancellation matrix.
+
 ## Security
 
 - 🔒 **Private keys** are encrypted at rest using AES-256 (via Fernet)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -26,8 +26,8 @@ def test_timeout_config_respected():
 
 def test_timeout_returns_error():
     """A timeout during a tool call returns an MCP error, not a hang."""
-    from rustchain_mcp.server import _make_client, RUSTCHAIN_NODE
-    client = _make_client()
+    from rustchain_mcp.server import get_client, RUSTCHAIN_NODE
+    client = get_client()
 
     with patch.object(client, "get", side_effect=httpx.TimeoutException("timed out")):
         with pytest.raises(httpx.TimeoutException):
@@ -36,8 +36,8 @@ def test_timeout_returns_error():
 
 def test_connection_refused_returns_error():
     """Connection refused during a read tool returns a meaningful error."""
-    from rustchain_mcp.server import _make_client, RUSTCHAIN_NODE
-    client = _make_client()
+    from rustchain_mcp.server import get_client, RUSTCHAIN_NODE
+    client = get_client()
 
     with patch.object(client, "get", side_effect=httpx.ConnectError("Connection refused")):
         with pytest.raises(httpx.ConnectError):
@@ -46,8 +46,8 @@ def test_connection_refused_returns_error():
 
 def test_http_404_formatted():
     """HTTP 404 from a tool returns a clear error, not a cryptic trace."""
-    from rustchain_mcp.server import _make_client, RUSTCHAIN_NODE
-    client = _make_client()
+    from rustchain_mcp.server import get_client, RUSTCHAIN_NODE
+    client = get_client()
 
     mock_resp = MagicMock(spec=httpx.Response)
     mock_resp.status_code = 404
@@ -64,8 +64,8 @@ def test_http_404_formatted():
 
 def test_cancellation_safety():
     """Cancelling a tool does not leave a pending operation on the node."""
-    from rustchain_mcp.server import _make_client, RUSTCHAIN_NODE
-    client = _make_client()
+    from rustchain_mcp.server import get_client, RUSTCHAIN_NODE
+    client = get_client()
 
     mock_resp = MagicMock(spec=httpx.Response)
     mock_resp.status_code = 200

--- a/tests/test_streaming_contract.py
+++ b/tests/test_streaming_contract.py
@@ -1,0 +1,97 @@
+"""Contract tests pinning down rustchain-mcp streaming / long-running behavior.
+
+Answers rustchain-mcp#231: the server does NOT stream results and does NOT
+emit MCP progress notifications. Tools are synchronous, blocking callables
+that return a single completed result. These tests fail if streaming /
+progress support is later added (i.e. the documented capability claim is
+flipped), which is exactly what the bounty requires.
+"""
+
+import asyncio
+import inspect
+import time
+from unittest.mock import MagicMock
+
+from rustchain_mcp import server
+
+
+def _all_tool_fns():
+    """Return {name: underlying_callable} for every registered MCP tool."""
+    tools = asyncio.run(server.mcp.list_tools())
+    return {t.name: t.fn for t in tools}
+
+
+def test_no_tool_accepts_progress_context():
+    """No tool takes a `ctx`/`context` param, so none can emit progress.
+
+    FastMCP only reports `notifications/progress` when a tool accepts a
+    `Context` argument and calls `ctx.report_progress(...)`. Asserting the
+    absence of such a parameter proves the server cannot stream progress.
+    """
+    for name, fn in _all_tool_fns().items():
+        params = list(inspect.signature(fn).parameters.keys())
+        assert not any(p in ("ctx", "context") for p in params), (
+            f"Tool '{name}' accepts a progress context ({params}); "
+            "this contradicts the documented 'no streaming/progress' behavior"
+        )
+
+
+def test_no_tool_is_a_generator_or_async_generator():
+    """Streaming tools would be generators/async-generators; ours are not.
+
+    A streaming tool yields partial results; a blocking tool returns a single
+    value. Asserting no tool is a generator pins the blocking contract.
+    """
+    for name, fn in _all_tool_fns().items():
+        assert not (inspect.isgeneratorfunction(fn) or inspect.isasyncgenfunction(fn)), (
+            f"Tool '{name}' is a generator — it would stream partial results, "
+            "contradicting the documented blocking behavior"
+        )
+
+
+def test_server_advertises_no_experimental_streaming_capability():
+    """The server exposes no experimental capability flag for streaming."""
+    assert getattr(server.mcp, "experimental_capabilities", None) == {}, (
+        "experimental_capabilities is non-empty; streaming may be advertised"
+    )
+
+
+def test_slow_tool_blocks_until_complete_and_returns_single_result():
+    """A slow upstream call blocks the tool until the full result is ready.
+
+    We mock the shared httpx client so GET /health is slow, then assert the
+    tool returns exactly one completed dict after the full delay (never a
+    partial/early result). If the server streamed, this would return early or
+    yield progress instead of a single result.
+    """
+    payload = {"status": "ok", "version": "1.2.3"}
+
+    def _slow_get(url, **kwargs):
+        time.sleep(0.25)
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json = lambda: dict(payload)
+        resp.raise_for_status = lambda: None
+        return resp
+
+    fake = MagicMock()
+    fake.get.side_effect = _slow_get
+
+    saved = server._client
+    server._client = fake
+    try:
+        start = time.perf_counter()
+        result = server.rustchain_health()
+        elapsed = time.perf_counter() - start
+    finally:
+        server._client = saved
+
+    # Blocked for (at least) the full upstream delay -> single blocking call.
+    assert elapsed >= 0.2, (
+        f"tool returned early ({elapsed:.3f}s); expected to block ~0.25s"
+    )
+    # Single completed result, not a stream/partial.
+    assert isinstance(result, dict), f"expected a single dict result, got {type(result)}"
+    assert result.get("status") == "ok"
+    # Exactly one upstream GET happened (no partial chunking / progress polling).
+    assert fake.get.call_count == 1


### PR DESCRIPTION
## Summary

Answers **rustchain-mcp#231** ("Does rustchain-mcp support tool streaming / progressive results?") with code-backed evidence and pins the behavior down with tests.

**Answer: No.** The server does **not** support SSE streaming or MCP `notifications/progress`. Every tool is a **synchronous, blocking** call that awaits the full upstream HTTP response and returns a single completed JSON result.

## Code references (rustchain_mcp/server.py)

- `mcp = FastMCP(...)` — `rustchain_mcp/server.py:41`. Tools are plain `@mcp.tool()` functions (first at line 86, `rustchain_health`), all synchronous, returning a `dict`/`list`.
- `get_client()` returns **one shared, blocking** `httpx.Client(timeout=RUSTCHAIN_TIMEOUT, verify=_TLS_VERIFY)` — `rustchain_mcp/server.py:64-67`. Tools call `client.get(...)`/`client.post(...)` and block on the response.
- **None of the 37 registered tools accept a `ctx`/`context` parameter**, so none can emit progress notifications (FastMCP only reports progress when a tool takes a `Context` and calls `ctx.report_progress(...)`).
- **No tool is a generator / async-generator** — nothing yields partial/streamed results.
- `mcp.experimental_capabilities == {}` — no experimental streaming capability is advertised.

## Deliverable (bounty Scottcjn/rustchain-bounties#16255)

1. Added a **"Streaming & Long-Running Tools"** section to `README.md` documenting the real behavior + the MCP capability flags the server advertises (and which it does not: `progress`/`logging`).
2. Added `tests/test_streaming_contract.py` asserting the documented contract:
   - `test_no_tool_accepts_progress_context`
   - `test_no_tool_is_a_generator_or_async_generator`
   - `test_server_advertises_no_experimental_streaming_capability`
   - `test_slow_tool_blocks_until_complete_and_returns_single_result` — a mocked slow `GET /health` blocks the tool for the full delay and returns exactly one completed result (no partial/progress output).
   These tests **fail if streaming/progress is ever added** (the capability claim is flipped).
3. Fixed `tests/test_streaming.py`: it referenced a nonexistent `_make_client`; changed to the real `get_client()` so the suite actually runs (4 tests were `ImportError`).
4. All 10 streaming tests pass offline (`pytest tests/test_streaming.py tests/test_streaming_contract.py` → 10 passed).

Closes #231.

RTC wallet for bounty payout: 0x4E248Ba82B6f8A6D6a3EFfF48dFE402a8e6d01e3
